### PR TITLE
Use OpenResty 1.15.8.3 instead of vanilla nginx 1.17.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,19 @@ FROM alpine:latest as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ENV NGINX_VERSION=1.17.10
+ENV NGINX_VERSION=1.15.8.3
+# Note: OpenResty does not support Lua >= 5.2
+ENV LUA_VERSION=5.1.5
+ENV LUAROCKS_VERSION=3.3.1
 
 RUN apk update
 RUN apk add --no-cache --upgrade bash curl ncurses openssl
-RUN apk add --update gcc g++ musl-dev make pcre pcre-dev openssl-dev zlib-dev
+RUN apk add --update gcc g++ musl-dev make pcre pcre-dev openssl-dev zlib-dev readline-dev perl
 RUN apk add build-base
+
+# Lua build
+ADD ./scripts/build-lua /tmp/build-lua
+RUN /tmp/build-lua
 
 # Nginx build
 ADD ./scripts/build-nginx /tmp/build-nginx
@@ -20,18 +27,30 @@ RUN /tmp/build-nginx
 FROM alpine:latest
 LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 
-ENV NGINX_VERSION=1.17.10
+ENV NGINX_VERSION=1.15.8.3
+# Note: OpenResty does not support Lua >= 5.2
+ENV LUA_VERSION=5.1.5
+ENV LUAROCKS_VERSION=3.3.1
 
+# OpenResty uses LuaJIT which has a dependency on GCC
 RUN apk update \
-	&& apk add curl bash figlet ncurses openssl pcre zlib apache2-utils tzdata \
+	&& apk add gcc musl-dev curl bash figlet ncurses openssl pcre zlib apache2-utils tzdata perl readline unzip \
 	&& apk add --update make \
 	&& rm -rf /var/cache/apk/*
 
 ADD ./.bashrc /root/.bashrc
 
+# Copy lua and luarocks builds from first image
+COPY --from=builder /tmp/lua /tmp/lua
+COPY --from=builder /tmp/luarocks /tmp/luarocks
+ADD ./scripts/install-lua /tmp/install-lua
+
 # Copy nginx build from first image
 COPY --from=builder /tmp/nginx /tmp/nginx
 ADD ./scripts/install-nginx /tmp/install-nginx
-RUN /tmp/install-nginx \
+
+RUN /tmp/install-lua \
+    && /tmp/install-nginx \
+	&& rm -f /tmp/install-lua \
 	&& rm -f /tmp/install-nginx \
 	&& apk del make

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -3,21 +3,29 @@ LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ENV NGINX_VERSION=1.17.10
+ENV NGINX_VERSION=1.15.8.3
+# Note: OpenResty does not support Lua >= 5.2
+ENV LUA_VERSION=5.1.5
+ENV LUAROCKS_VERSION=3.3.1
 
 RUN apk update \
 	&& update-ca-certificates \
 	&& apk add --no-cache --upgrade bash curl ncurses openssl \
-	&& apk add --update gcc g++ musl-dev make pcre pcre-dev openssl-dev zlib-dev figlet zlib apache2-utils tzdata \
+	&& apk add --update gcc g++ musl-dev make pcre pcre-dev openssl-dev zlib-dev figlet zlib apache2-utils tzdata readline-dev perl unzip \
 	&& apk add build-base git npm nodejs-current yarn \
 	&& rm -rf /var/cache/apk/*
 
 ADD ./.bashrc /root/.bashrc
 
+# Lua build
+ADD ./scripts/build-lua /tmp/build-lua
+ADD ./scripts/install-lua /tmp/install-lua
+
 # Nginx build
 ADD ./scripts/build-nginx /tmp/build-nginx
 ADD ./scripts/install-nginx /tmp/install-nginx
-RUN /tmp/build-nginx && /tmp/install-nginx
+
+RUN /tmp/build-lua && /tmp/install-lua && /tmp/build-nginx && /tmp/install-nginx
 
 WORKDIR /root
 

--- a/scripts/build-lua
+++ b/scripts/build-lua
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+BLUE='\E[1;34m'
+CYAN='\E[1;36m'
+YELLOW='\E[1;33m'
+GREEN='\E[1;32m'
+RESET='\E[0m'
+
+echo -e "${BLUE}❯ ${CYAN}Building Lua ${YELLOW}${LUA_VERSION}...${RESET}"
+
+cd /tmp
+wget "http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz"
+tar -xzf lua-${LUA_VERSION}.tar.gz
+mv /tmp/lua-${LUA_VERSION} /tmp/lua
+cd /tmp/lua
+
+make linux test
+# We have to install Lua for the Luarocks build to succeed, it will be installed again when building the final image
+make install
+
+echo -e "${BLUE}❯ ${GREEN}Lua build completed${RESET}"
+
+echo -e "${BLUE}❯ ${CYAN}Building Luarocks ${YELLOW}${LUAROCKS_VERSION}...${RESET}"
+
+cd /tmp
+wget "http://luarocks.github.io/luarocks/releases/luarocks-${LUAROCKS_VERSION}.tar.gz"
+tar -xzf luarocks-${LUAROCKS_VERSION}.tar.gz
+mv /tmp/luarocks-${LUAROCKS_VERSION} /tmp/luarocks
+cd /tmp/luarocks
+
+./configure
+make
+
+echo -e "${BLUE}❯ ${GREEN}Luarocks build completed${RESET}"

--- a/scripts/build-nginx
+++ b/scripts/build-nginx
@@ -6,12 +6,12 @@ YELLOW='\E[1;33m'
 GREEN='\E[1;32m'
 RESET='\E[0m'
 
-echo -e "${BLUE}❯ ${CYAN}Building nginx ${YELLOW}${NGINX_VERSION}...${RESET}"
+echo -e "${BLUE}❯ ${CYAN}Building OpenResty ${YELLOW}${NGINX_VERSION}...${RESET}"
 
 cd /tmp
-wget "http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
-tar -xzf nginx-${NGINX_VERSION}.tar.gz
-mv /tmp/nginx-${NGINX_VERSION} /tmp/nginx
+wget "https://openresty.org/download/openresty-${NGINX_VERSION}.tar.gz"
+tar -xzf openresty-${NGINX_VERSION}.tar.gz
+mv /tmp/openresty-${NGINX_VERSION} /tmp/nginx
 cd /tmp/nginx
 
 ./configure \
@@ -56,4 +56,4 @@ cd /tmp/nginx
 
 make
 
-echo -e "${BLUE}❯ ${GREEN}Nginx build completed${RESET}"
+echo -e "${BLUE}❯ ${GREEN}OpenResty build completed${RESET}"

--- a/scripts/install-lua
+++ b/scripts/install-lua
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+BLUE='\E[1;34m'
+CYAN='\E[1;36m'
+YELLOW='\E[1;33m'
+GREEN='\E[1;32m'
+RESET='\E[0m'
+
+echo -e "${BLUE}❯ ${CYAN}Installing Lua ${YELLOW}${LUA_VERSION}...${RESET}"
+
+cd /tmp/lua
+make install
+rm -rf /tmp/lua
+
+echo -e "${BLUE}❯ ${GREEN}Lua install completed${RESET}"
+
+echo -e "${BLUE}❯ ${CYAN}Installing Luarocks ${YELLOW}${LUAROCKS_VERSION}...${RESET}"
+
+cd /tmp/luarocks
+make install
+rm -rf /tmp/luarocks
+
+echo -e "${BLUE}❯ ${GREEN}Luarocks install completed${RESET}"

--- a/scripts/install-nginx
+++ b/scripts/install-nginx
@@ -6,10 +6,18 @@ YELLOW='\E[1;33m'
 GREEN='\E[1;32m'
 RESET='\E[0m'
 
-echo -e "${BLUE}❯ ${CYAN}Installing nginx ${YELLOW}${NGINX_VERSION}...${RESET}"
+echo -e "${BLUE}❯ ${CYAN}Installing OpenResty ${YELLOW}${NGINX_VERSION}...${RESET}"
 
 cd /tmp/nginx
 make install
 rm -rf /tmp/nginx
 
-echo -e "${BLUE}❯ ${GREEN}Nginx install completed${RESET}"
+echo -e "${BLUE}❯ ${GREEN}OpenResty install completed${RESET}"
+
+echo -e "${BLUE}❯ ${CYAN}Installing OpenResty plugins...${RESET}"
+
+cd /
+luarocks install lua-cjson
+luarocks install lua-resty-openidc
+
+echo -e "${BLUE}❯ ${GREEN}OpenResty plugins install completed${RESET}"


### PR DESCRIPTION
This lets us load Lua plugins for things like OpenID Connect support. We install the `lua-resty-openidc` plugin by default.

OpenResty has a dependency on LuaJIT which has a dependency on GCC, so the final image now contains both the gcc and musl-dev packages, making it slightly bigger than before.

Versions used in the new build:

`OpenResty v1.15.8.3`
`Lua v5.1.5` (OpenResty does not support any Lua version >= 5.2)
`LuaRocks v3.3.1`